### PR TITLE
Add chatbot accessibility features, fix UI and message send functionality

### DIFF
--- a/project/static/js/srs_chatbot.js
+++ b/project/static/js/srs_chatbot.js
@@ -4,7 +4,14 @@
     return;
   }
 
+  var TEXT_SIZE_STORAGE_KEY = 'srsChatbotTextSize';
+  var TEXT_SIZE_DEFAULT = '100';
+  var TEXT_SIZE_OPTIONS = ['60', '80', '100', '110', '120', '150'];
   var toggle = root.querySelector('.srs-chatbot-toggle');
+  var settingsToggle = root.querySelector('.srs-chatbot-settings-toggle');
+  var settingsPanel = root.querySelector('.srs-chatbot-settings');
+  var settingsClose = root.querySelector('.srs-chatbot-settings-close');
+  var textSizeInputs = root.querySelectorAll('input[name="srs-chatbot-text-size"]');
   var minimize = root.querySelector('.srs-chatbot-minimize');
   var windowEl = root.querySelector('.srs-chatbot-window');
   var form = root.querySelector('.srs-chatbot-form');
@@ -24,6 +31,53 @@
 
     hours = hours % 12 || 12;
     return month + ' ' + day + ', ' + hours + ':' + minutes + ' ' + period;
+  }
+
+  function getStoredTextSize() {
+    var storedSize;
+
+    try {
+      storedSize = window.localStorage.getItem(TEXT_SIZE_STORAGE_KEY);
+    } catch (error) {
+      storedSize = null;
+    }
+
+    return TEXT_SIZE_OPTIONS.indexOf(storedSize) !== -1 ? storedSize : TEXT_SIZE_DEFAULT;
+  }
+
+  function storeTextSize(size) {
+    try {
+      window.localStorage.setItem(TEXT_SIZE_STORAGE_KEY, size);
+    } catch (error) {
+      return;
+    }
+  }
+
+  function applyTextSize(size, persist) {
+    var selectedSize = TEXT_SIZE_OPTIONS.indexOf(size) !== -1 ? size : TEXT_SIZE_DEFAULT;
+
+    windowEl.style.setProperty('--srs-chatbot-text-size', selectedSize + '%');
+    Array.prototype.forEach.call(textSizeInputs, function (input) {
+      input.checked = input.value === selectedSize;
+    });
+
+    if (persist) {
+      storeTextSize(selectedSize);
+    }
+  }
+
+  function setSettingsOpen(isOpen) {
+    if (!settingsPanel || !settingsToggle) {
+      return;
+    }
+
+    settingsPanel.hidden = !isOpen;
+    settingsToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    if (isOpen) {
+      (settingsPanel.querySelector('input:checked') || settingsPanel.querySelector('input') || settingsClose).focus();
+    } else {
+      settingsToggle.focus();
+    }
   }
 
   function setOpen(isOpen) {
@@ -275,6 +329,18 @@
     setOpen(windowEl.hidden);
   });
 
+  if (settingsToggle) {
+    settingsToggle.addEventListener('click', function () {
+      setSettingsOpen(settingsPanel.hidden);
+    });
+  }
+
+  if (settingsClose) {
+    settingsClose.addEventListener('click', function () {
+      setSettingsOpen(false);
+    });
+  }
+
   if (minimize) {
     minimize.addEventListener('click', function () {
       setOpen(false);
@@ -287,9 +353,26 @@
     });
   });
 
+  Array.prototype.forEach.call(textSizeInputs, function (input) {
+    input.addEventListener('change', function () {
+      if (input.checked) {
+        applyTextSize(input.value, true);
+      }
+    });
+  });
+
+  windowEl.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape' && settingsPanel && !settingsPanel.hidden) {
+      event.preventDefault();
+      setSettingsOpen(false);
+    }
+  });
+
   if (timestamp) {
     timestamp.textContent = formatTimestamp(new Date());
   }
+
+  applyTextSize(getStoredTextSize(), false);
 
   form.addEventListener('submit', function (event) {
     event.preventDefault();

--- a/project/static/js/srs_chatbot.js
+++ b/project/static/js/srs_chatbot.js
@@ -21,6 +21,7 @@
   var timestamp = root.querySelector('.srs-chatbot-timestamp');
   var csrfInput = root.querySelector('input[name="csrfmiddlewaretoken"]');
   var endpoint = root.getAttribute('data-chatbot-endpoint');
+  var isComposing = false;
 
   function formatTimestamp(date) {
     var month = date.toLocaleString('en-US', { month: 'long' });
@@ -288,6 +289,18 @@
     });
   }
 
+  function submitChatForm() {
+    if (typeof form.requestSubmit === 'function') {
+      form.requestSubmit();
+      return;
+    }
+
+    form.dispatchEvent(new Event('submit', {
+      bubbles: true,
+      cancelable: true
+    }));
+  }
+
   function sendMessage(query) {
     appendMessage(query, 'user');
     input.value = '';
@@ -384,5 +397,22 @@
     }
 
     sendMessage(query);
+  });
+
+  input.addEventListener('compositionstart', function () {
+    isComposing = true;
+  });
+
+  input.addEventListener('compositionend', function () {
+    isComposing = false;
+  });
+
+  input.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter' || event.shiftKey || event.isComposing || isComposing) {
+      return;
+    }
+
+    event.preventDefault();
+    submitChatForm();
   });
 }());

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -267,6 +267,7 @@
 			pointer-events:auto;
 		}
 		.srs-chatbot-window {
+			--srs-chatbot-text-size:100%;
 			position:absolute;
 			right:0;
 			top:0;
@@ -279,6 +280,7 @@
 			background:#ffffff;
 			border:0;
 			border-left:2px solid #00274c;
+			font-size:var(--srs-chatbot-text-size);
 			pointer-events:auto;
 		}
 		.srs-chatbot-window,
@@ -300,11 +302,12 @@
 		.srs-chatbot-header h2 {
 			margin:0;
 			color:#ffcb05;
-			font-size:1.15rem;
+			font-size:1.15em;
 			font-weight:700;
 			text-align:center;
 		}
 		.srs-chatbot-toggle,
+		.srs-chatbot-settings-toggle,
 		.srs-chatbot-minimize,
 		.srs-chatbot-form button {
 			border:0;
@@ -313,6 +316,8 @@
 		}
 		.srs-chatbot-toggle:focus,
 		.srs-chatbot-toggle:hover,
+		.srs-chatbot-settings-toggle:focus,
+		.srs-chatbot-settings-toggle:hover,
 		.srs-chatbot-minimize:focus,
 		.srs-chatbot-minimize:hover,
 		.srs-chatbot-form button:focus,
@@ -324,10 +329,66 @@
 			margin-bottom:8px;
 			color:#ffcb05;
 		}
+		.srs-chatbot-settings-toggle {
+			background:transparent;
+			font-size:1.1em;
+			justify-self:start;
+		}
 		.srs-chatbot-minimize {
 			background:transparent;
-			font-size:1.2rem;
+			font-size:1.2em;
 			justify-self:end;
+		}
+		.srs-chatbot-settings {
+			position:absolute;
+			top:62px;
+			left:16px;
+			z-index:1;
+			width:220px;
+			padding:12px;
+			background:#ffffff;
+			border:2px solid #00274c;
+			box-shadow:0 4px 12px rgba(0, 0, 0, .18);
+		}
+		.srs-chatbot-settings[hidden] {
+			display:none;
+		}
+		.srs-chatbot-settings-header {
+			display:flex;
+			align-items:center;
+			justify-content:space-between;
+			margin-bottom:10px;
+		}
+		.srs-chatbot-settings-header h3 {
+			margin:0;
+			color:#00274c;
+			font-size:1em;
+		}
+		.srs-chatbot-settings-close {
+			border:0;
+			background:transparent;
+			color:#00274c;
+		}
+		.srs-chatbot-settings fieldset {
+			margin:0;
+			padding:0;
+			border:0;
+		}
+		.srs-chatbot-settings legend {
+			margin-bottom:6px;
+			color:#313131;
+			font-weight:700;
+		}
+		.srs-chatbot-text-size-options {
+			display:grid;
+			grid-template-columns:repeat(2, 1fr);
+			gap:6px 10px;
+		}
+		.srs-chatbot-text-size-options label {
+			display:flex;
+			align-items:center;
+			gap:4px;
+			margin:0;
 		}
 		.srs-chatbot-messages {
 			flex:1;
@@ -342,13 +403,13 @@
 		.srs-chatbot-welcome h3 {
 			margin:0 0 8px 0;
 			color:#313131;
-			font-size:2rem;
+			font-size:2em;
 			font-weight:700;
 		}
 		.srs-chatbot-timestamp,
 		.srs-chatbot-note {
 			color:#a0a7aa;
-			font-size:.75rem;
+			font-size:.75em;
 		}
 		.srs-chatbot-chat-meta {
 			margin-bottom:8px;
@@ -415,17 +476,17 @@
 		.srs-chatbot-option .fas {
 			width:42px;
 			color:#00274c;
-			font-size:1.8rem;
+			font-size:1.8em;
 			text-align:center;
 		}
 		.srs-chatbot-option strong {
 			display:block;
 			color:#00274c;
-			font-size:1rem;
+			font-size:1em;
 		}
 		.srs-chatbot-option span {
 			display:block;
-			font-size:.82rem;
+			font-size:.82em;
 			line-height:1.25;
 		}
 		.srs-chatbot-form {
@@ -441,14 +502,15 @@
 		.srs-chatbot-form textarea {
 			flex:1;
 			min-width:0;
-			height:36px;
-			min-height:36px;
-			max-height:36px;
-			padding:7px 0;
+			height:2.4em;
+			min-height:2.4em;
+			max-height:4.8em;
+			padding:.55em 0;
 			border:0;
 			color:#313131;
-			line-height:20px;
-			overflow:hidden;
+			font-size:1em;
+			line-height:1.3;
+			overflow:auto;
 			resize:none;
 		}
 		.srs-chatbot-form textarea::placeholder {
@@ -484,12 +546,33 @@
 		</button>
 		<section class="srs-chatbot-window" id="srs-chatbot-window" aria-label="Chatbot" hidden>
 			<header class="srs-chatbot-header">
-				<span></span>
+				<button class="srs-chatbot-settings-toggle" type="button" aria-label="Open chatbot settings" aria-expanded="false" aria-controls="srs-chatbot-settings">
+					<span class="fas fa-cog" aria-hidden="true"></span>
+				</button>
 				<h2>SRS Chatbot</h2>
 				<button class="srs-chatbot-minimize" type="button" aria-label="Minimize chat">
 					<span class="fas fa-minus" aria-hidden="true"></span>
 				</button>
 			</header>
+			<div class="srs-chatbot-settings" id="srs-chatbot-settings" aria-label="Chatbot settings" hidden>
+				<div class="srs-chatbot-settings-header">
+					<h3>Settings</h3>
+					<button class="srs-chatbot-settings-close" type="button" aria-label="Close chatbot settings">
+						<span class="fas fa-times" aria-hidden="true"></span>
+					</button>
+				</div>
+				<fieldset>
+					<legend>Text size</legend>
+					<div class="srs-chatbot-text-size-options">
+						<label><input type="radio" name="srs-chatbot-text-size" value="60">60%</label>
+						<label><input type="radio" name="srs-chatbot-text-size" value="80">80%</label>
+						<label><input type="radio" name="srs-chatbot-text-size" value="100">100%</label>
+						<label><input type="radio" name="srs-chatbot-text-size" value="110">110%</label>
+						<label><input type="radio" name="srs-chatbot-text-size" value="120">120%</label>
+						<label><input type="radio" name="srs-chatbot-text-size" value="150">150%</label>
+					</div>
+				</fieldset>
+			</div>
 			<div class="srs-chatbot-messages" aria-live="polite">
 				<div class="srs-chatbot-welcome">
 					<h3>Welcome!</h3>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -501,18 +501,18 @@
 					<p><strong>What do you need help with today?</strong></p>
 				</div>
 				<div class="srs-chatbot-options">
-					<button class="srs-chatbot-option" type="button" data-prompt="I need help with IT services support.">
-						<span class="fas fa-desktop" aria-hidden="true"></span>
-						<span>
-							<strong>IT Services Support</strong>
-							<span>Get help with service requests, accounts, software, and other technology-related questions.</span>
-						</span>
-					</button>
 					<button class="srs-chatbot-option" type="button" data-prompt="I need help with telephony support.">
 						<span class="fas fa-phone-volume" aria-hidden="true"></span>
 						<span>
-							<strong>Telephony Support</strong>
+							<strong>Telephone, Data, &amp; Video Support</strong>
 							<span>Request or manage phone features, videoconferencing, and other telecommunications services.</span>
+						</span>
+					</button>
+					<button class="srs-chatbot-option" type="button" data-prompt="I need help with IT services support.">
+						<span class="fas fa-desktop" aria-hidden="true"></span>
+						<span>
+							<strong>Other ITS Services Support</strong>
+							<span>Get help with service requests, accounts, software, and other technology-related questions.</span>
 						</span>
 					</button>
 				</div>

--- a/project/tests_chatbot.py
+++ b/project/tests_chatbot.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+BASE_TEMPLATE = Path(__file__).resolve().parent / "templates" / "base.html"
+CHATBOT_SCRIPT = Path(__file__).resolve().parent / "static" / "js" / "srs_chatbot.js"
+
+
+class ChatbotTemplateTests(SimpleTestCase):
+    def setUp(self):
+        self.template = BASE_TEMPLATE.read_text()
+
+    def test_support_options_are_ordered_and_renamed(self):
+        telephony_title = "Telephone, Data, &amp; Video Support"
+        its_title = "Other ITS Services Support"
+
+        self.assertIn(telephony_title, self.template)
+        self.assertIn(its_title, self.template)
+        self.assertLess(self.template.index(telephony_title), self.template.index(its_title))
+        self.assertNotIn("<strong>Telephony Support</strong>", self.template)
+        self.assertNotIn("<strong>IT Services Support</strong>", self.template)

--- a/project/tests_chatbot.py
+++ b/project/tests_chatbot.py
@@ -20,3 +20,38 @@ class ChatbotTemplateTests(SimpleTestCase):
         self.assertLess(self.template.index(telephony_title), self.template.index(its_title))
         self.assertNotIn("<strong>Telephony Support</strong>", self.template)
         self.assertNotIn("<strong>IT Services Support</strong>", self.template)
+
+    def test_text_size_settings_are_accessible_and_default_to_100_percent(self):
+        self.assertIn("--srs-chatbot-text-size:100%;", self.template)
+        self.assertIn('aria-label="Open chatbot settings"', self.template)
+        self.assertIn('aria-expanded="false"', self.template)
+        self.assertIn('aria-controls="srs-chatbot-settings"', self.template)
+        self.assertIn('id="srs-chatbot-settings"', self.template)
+        self.assertIn('aria-label="Chatbot settings"', self.template)
+        self.assertIn('aria-label="Close chatbot settings"', self.template)
+        self.assertIn("<legend>Text size</legend>", self.template)
+
+    def test_all_requested_text_size_options_are_available(self):
+        for size in ["60", "80", "100", "110", "120", "150"]:
+            self.assertIn(f'name="srs-chatbot-text-size" value="{size}"', self.template)
+
+
+class ChatbotScriptTests(SimpleTestCase):
+    def setUp(self):
+        self.script = CHATBOT_SCRIPT.read_text()
+
+    def test_text_size_selection_updates_and_persists(self):
+        self.assertIn("TEXT_SIZE_DEFAULT = '100'", self.script)
+        self.assertIn("TEXT_SIZE_STORAGE_KEY = 'srsChatbotTextSize'", self.script)
+        self.assertIn("window.localStorage.getItem(TEXT_SIZE_STORAGE_KEY)", self.script)
+        self.assertIn("window.localStorage.setItem(TEXT_SIZE_STORAGE_KEY, size)", self.script)
+        self.assertIn("windowEl.style.setProperty('--srs-chatbot-text-size'", self.script)
+        self.assertIn("input.checked = input.value === selectedSize", self.script)
+        self.assertIn("applyTextSize(getStoredTextSize(), false)", self.script)
+
+    def test_settings_panel_keyboard_accessibility(self):
+        self.assertIn("settingsToggle.addEventListener('click'", self.script)
+        self.assertIn("settingsClose.addEventListener('click'", self.script)
+        self.assertIn("settingsToggle.setAttribute('aria-expanded'", self.script)
+        self.assertIn("event.key === 'Escape'", self.script)
+        self.assertIn("setSettingsOpen(false)", self.script)

--- a/project/tests_chatbot.py
+++ b/project/tests_chatbot.py
@@ -55,3 +55,20 @@ class ChatbotScriptTests(SimpleTestCase):
         self.assertIn("settingsToggle.setAttribute('aria-expanded'", self.script)
         self.assertIn("event.key === 'Escape'", self.script)
         self.assertIn("setSettingsOpen(false)", self.script)
+
+    def test_enter_to_send_uses_existing_submit_handler(self):
+        self.assertIn("input.addEventListener('keydown'", self.script)
+        self.assertIn("event.key !== 'Enter'", self.script)
+        self.assertIn("event.preventDefault()", self.script)
+        self.assertIn("submitChatForm()", self.script)
+        self.assertIn("form.requestSubmit()", self.script)
+        self.assertIn("form.addEventListener('submit'", self.script)
+
+    def test_enter_to_send_keeps_existing_guards(self):
+        self.assertIn("var query = input.value.trim()", self.script)
+        self.assertIn("if (!query)", self.script)
+        self.assertIn("event.shiftKey", self.script)
+        self.assertIn("event.isComposing", self.script)
+        self.assertIn("isComposing", self.script)
+        self.assertIn("compositionstart", self.script)
+        self.assertIn("compositionend", self.script)


### PR DESCRIPTION
Added:
- Accessibility settings dropdown on the chatbot window, features text size option with radio buttons for 60, 80, 100, 110, 120, 150%

Changed:
- Rename 'Telephony' to 'Telephone, Data, & Video Support' to align with existing SRS menus
- Rename 'IT Services' to 'Other ITS Services Support' to align with existing SRS menus
- Reorder clickable options to 'Telephone, Data, & Video Support' exists above 'Other ITS Services Support'

Fixed:
- Messages send on enter in chatbot window